### PR TITLE
Add statement about .NET unsafe code

### DIFF
--- a/docs/best-practice-memory-safe-by-default-languages.md
+++ b/docs/best-practice-memory-safe-by-default-languages.md
@@ -20,7 +20,7 @@ TO DO
 
 ## .NET
 
-TO DO
+* Use unsafe blocks sparingly and [follow guidance](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/unsafe-code)
 
 ## JavaScript
 


### PR DESCRIPTION
This addition is not the sole/exhaustive guidance on .NET/C# and unsafe code. It is a first addition to this doc and a significant improvement over the prior text.